### PR TITLE
data literal for mongo id

### DIFF
--- a/src/data_readers.clj
+++ b/src/data_readers.clj
@@ -1,0 +1,1 @@
+{mongo/id mongo-driver-3.data-literals/mongo-id}

--- a/src/mongo_driver_3/data_literals.clj
+++ b/src/mongo_driver_3/data_literals.clj
@@ -1,0 +1,10 @@
+(ns mongo-driver-3.data-literals
+  (:import (org.bson.types ObjectId)
+           (java.io Writer)))
+
+
+(defmethod print-method ObjectId [c ^Writer w] (.write w ^String (str "#mongo/id \"" (.toHexString c) "\"")))
+(defmethod print-dup ObjectId [c ^Writer w] (.write w ^String (str "#mongo/id \"" (.toHexString c) "\"")))
+
+(defn mongo-id [o]
+  (ObjectId. o))


### PR DESCRIPTION
users can require ns `mongo-driver-3.data-literals` then will have literal : `#mongo/id"5f119fcb34046a73d16defa8"`