### PR TITLE
Add a helper method for implicit transactions

### DIFF
--- a/src/mongo_driver_3/client.clj
+++ b/src/mongo_driver_3/client.clj
@@ -145,6 +145,20 @@
                        (execute [_] (body)))
                      (->TransactionOptions opts))))
 
+
+(def ^:dynamic *session* nil)
+
+(defn with-implicit-transaction
+  "Automatically sets the session / transaction for all mongo operations
+   within the scope, using a dynamic binding"
+  [{:keys [^MongoClient client transaction-opts session-opts] :or {transaction-opts {} session-opts {}}} body]
+  (with-open [^ClientSession session (start-session client session-opts)]
+    (binding [*session* session]
+      (with-transaction
+        *session*
+        body
+        transaction-opts))))
+
 ;;; Utility
 
 (defn connect-to-db


### PR DESCRIPTION
Currently using transactions requires manually managing the opening and closing of a session as well as passing it in to everything that uses it, which may be in nested functions etc.

This helper method allows you to dynamically bind a session so that for the duration of `(with-implicit-transaction {} (fn [] ...))` all mongo-driver calls will implicitly use the provided session, giving a much easier to manage transaction.